### PR TITLE
Updated to python3 -m pip for ubuntu upgrade compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ to test `make flameshot-keybindings`
 - Peek: switched from a deb to Flatpak
 - Upgraded github-cli version to 0.6.3
 - Upgraded protonmail-bridge to 1.2.6-1
+- Changed `pip3` to `python3 -m pip` for version compatibility
 
 ## Removed
 

--- a/scripts/install_python3_dependencies.sh
+++ b/scripts/install_python3_dependencies.sh
@@ -6,8 +6,8 @@ mkdir -p "$FOLDER"
 sudo chown -R "$USER:$USER" "$FOLDER"
 sudo chmod -R 755 "$FOLDER"
 
-pip3 install --user --upgrade pip
-pip3 install --upgrade keyrings.alt --user
-pip3 install --user --upgrade setuptools
-pip3 install --user wheel
-pip3 install --user -r requirements.txt
+python3 -m pip install --user --upgrade pip
+python3 -m pip install --upgrade keyrings.alt --user
+python3 -m pip install --user --upgrade setuptools
+python3 -m pip install --user wheel
+python3 -m pip install --user -r requirements.txt


### PR DESCRIPTION
Let Ubuntu’s `python3`decide which `pip` to use