### PR TITLE
Fixed bug 🐛 in custom keybindings list in gsettings 🎉

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped `zsh-users/zsh-autosuggestions` plugin from [iancleary/ansible-role-zsh_antibody](https://github.com/iancleary/ansible-role-zsh_antibody) role
 - Reorganized software documentation section into alphabetical categories
 - Bumped `gh` to `v0.11.0`
+- Fixed bug where gsetting custom entries list didn't contain hyper and flameshot
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ ifeq "$(HOSTNAME)" "$(RUNNER)"
 	ANSIBLE = $(INSTALL_ANSIBLE_ROLES) && $(ANSIBLE_PLAYBOOK)
 endif
 
+# Custome GNOME keybindings
+CUSTOM_KEYBINDING_BASE = /org/gnome/settings-daemon/plugins/media-keys/custom-keybindings
+
 # - to suppress if it doesn't exist
 -include make.env
 
@@ -335,8 +338,13 @@ flameshot:
 flameshot: ## Install Flameshot 0.6.0 Screenshot Tool and Create Custom GNOME Keybindings
 	@$(ANSIBLE) --tags="flameshot"
 
-flameshot-keybindings: ## Install Flameshot and Update gnome keybindings
-flameshot-keybindings:
+gsettings-keybindings:
+gsettings-keybindings:  ## Sets GNOME custom keybindings
+
+	gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['$(CUSTOM_KEYBINDING_BASE)/flameshot/','$(CUSTOM_KEYBINDING_BASE)/hyper/']"
+
+flameshot-keybindings: ## Flameshot custon GNOME keybindings
+flameshot-keybindings: gsettings-keybindings
 	# For whatever reason, I bricked my GNOME session trying this with ansible
 	# so for now, I'm just going to chain this to the new machine script
 	# and leave it as a make target
@@ -345,7 +353,6 @@ flameshot-keybindings:
 	# source: https://askubuntu.com/a/1116076
 
 	gsettings set org.gnome.settings-daemon.plugins.media-keys screenshot "[]"
-	gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/flameshot/']"
 	gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/flameshot/ name 'flameshot'
 	gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/flameshot/ command '/usr/bin/flameshot gui'
 	gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/flameshot/ binding 'Print'
@@ -381,10 +388,9 @@ gtk3-icon-browser:
 	# Installs in gnome-preferences role
 	@gtk3-icon-browser &
 
-hyper:
 hyper: ## Install Hyper (A terminal built on web technologies)
+hyper: gsettings-keybindings
 	@$(ANSIBLE) --tags="hyper"
-	gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/hyper/']"
 	gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/hyper/ name 'hyper'
 	gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/hyper/ command '/usr/local/bin/hyper'
 	gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/hyper/ binding '<Super>t'


### PR DESCRIPTION
Since I set up Hyper and Flameshot to use custom keybindings, I accidentally had both make targets only add their single value into the custom keybind list.

That resulted in either target disabling the other custom keybind...which was annoying and not intended.

Anyway...it is now fixed 🎉